### PR TITLE
README: Add list of personas

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ Contributions are welcome! If you have a new persona you'd like to add, please f
 
 Please ensure your JSON files follow the structure outlined in the existing files.
 
+## Personas in this repository
+
+- [examples/assistant](https://chat-ai.academiccloud.de/chat?import=https://raw.githubusercontent.com/gwdg/chat-ai-personas/refs/heads/main/examples/assistant.json):
+Just an example
+- [research/glossary](https://chat-ai.academiccloud.de/chat?import=https://raw.githubusercontent.com/gwdg/chat-ai-personas/refs/heads/main/research/glossary.json): Create short defintions for terms
+- [research/spellfix](https://chat-ai.academiccloud.de/chat?import=https://raw.githubusercontent.com/gwdg/chat-ai-personas/refs/heads/main/research/spellfix.json): Check for errors in text by regeneration and comparison
+- [translation/de_en](https://chat-ai.academiccloud.de/chat?import=https://raw.githubusercontent.com/gwdg/chat-ai-personas/refs/heads/main/translation/de_en.json): Simple German to English translator
+- [translation/en_de](https://chat-ai.academiccloud.de/chat?import=https://raw.githubusercontent.com/gwdg/chat-ai-personas/refs/heads/main/translation/en_de.json): Simple English to German translator
+
 ## License
 
 This project is licensed under the GPLv3 License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
I often find myself going to my old PR with the example links just to find a link to invoke the research/glossary persona. Create a list of the personas in this repository with clickable links right in the README.

This commit also appends a newline to the last line of the README, as any sensible editor will do by default.